### PR TITLE
milliseconds time precision

### DIFF
--- a/Receiver/telemetryParser2.py
+++ b/Receiver/telemetryParser2.py
@@ -30,7 +30,7 @@ def __getTime(recievedMillis: uint32) -> datetime:
 
     print("millisDelta: " + str(millisDelta.item()) + " -> ", end='')
     currentTime = lastGPSTime + timedelta(milliseconds = millisDelta.item())
-    print("Current Time: " + currentTime.strftime("%Y-%m-%d %H:%M:%S"))
+    print("Current Time: " + currentTime.strftime("%Y-%m-%d %H:%M:%S.%f"))
     return currentTime
 
 #CONFIG INIT REGION


### PR DESCRIPTION
Just changed format of console output for current time.

Imo, this is fine as it is. As mentioned in race strategy, the millisecond output from the RTC is ignored so there is an error of up to 999ms. But, this error is constant throughout all messages sent.

A fix for this involves changing and then reuploading the code for the telemetry board.
A new CAN message would need to be created as the existing time fix message has no spare bytes to add milliseconds fix.

I'm keeping this open just in case someone has a different opinion on this.