### PR TITLE
Integrating the pi RTC and auto switch to GPS RTC if available

### DIFF
--- a/Receiver/telemetryParser2.py
+++ b/Receiver/telemetryParser2.py
@@ -21,7 +21,10 @@ from numpy import uint32
 configFile: str = '../../CANTranslator/config/CANBusData(saved201022)Modified.xlsm' #testing with windows
 
 #TIME REGION
-lastGPSTime: datetime = datetime(year=1970, month=1, day=1, hour=3, minute=0, second=0, tzinfo=timezone.utc) #Excel does not support timezones tzinfo=timezone.utc
+#lastGPSTime: datetime = datetime(year=1970, month=1, day=1, hour=3, minute=0, second=0, tzinfo=timezone.utc) #Excel does not support timezones tzinfo=timezone.utc
+lastGPSTime: datetime = datetime.now(timezone.utc) #use this by default until the pi rtc goes out of sync (i.e the UPS fails). It can be resynced if reconnected to internet.
+                                                   #If out of sync AND the GPS rtc has failed, use line above and manually try and set a time close to the current time.
+
 timeFetched: uint32 = uint32(0) #Time since time variables were last updated in seconds #round(time.time() * 1000). Using numpy to force unsigned and integer overflows are needed
 def __getTime(recievedMillis: uint32) -> datetime:
     millisDelta: uint32 = recievedMillis - timeFetched

--- a/Telemetry/SensorInputs.cpp
+++ b/Telemetry/SensorInputs.cpp
@@ -108,7 +108,7 @@ void setupSensorInputs() {
   uint32_t timer = millis();
   DEBUG_PRINT("GPS time acquire timer: "); DEBUG_PRINTLN(timer);
   DEBUG_PRINT("GPS time acquire max: "); DEBUG_PRINTLN(config.time_fix);
-  while (1) {
+  while (0) { //Boot will skip GPS valid time check now. If GPS already has time fix (i.e. RTC is already set), then this shouldn't cause an issue. Otherwise, the pi rtc will be used until GPS gives a time fix message.s
       char c = GPS.read();
 #ifdef GPSECHO
       if(c)


### PR DESCRIPTION
As discussed last Sunday @VedikaBedi.
Basically, by default it will store the pi current time. This will be immediately overwritten by the GPS RTC if it is working.
If all RTCs are out of sync, then theres the option of manually setting the lastGPSTime variable to a time close to the current time.